### PR TITLE
Binder environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: lab-environment
+channels:
+  - conda-forge
+dependencies:
+  - python >=3.10,<3.13
+  - numpy >=1.23.0,<2.0.0
+  - tensorflow >=2.5,<2.17
+  - tensorflow-probability >=0.13,<0.25
+  - notebook
+  - matplotlib
+  - taskipy
+  - pip
+  - pip:
+    - trieste >=4.2


### PR DESCRIPTION
After some trials I have managed to figure out how to make a working binder environment for the first lab.

The repo needs to be public in order to host on [mybinder.org](https://mybinder.org/)

when the repo is public, you just go to [mybinder.org](https://mybinder.org/) and follow the instructions, which use docker to build and image of the conda built environment. This will be updated everytime a push is made to the repo and the container is accessed.

Here's an example with my public repo `binder_test`: https://github.com/alansaul/binder_test

1. Follow the instructions:
![image](https://github.com/user-attachments/assets/54637937-e2a7-4f63-9bd4-51941551e071)
2. Click Launch
3. Then access the mybinder container that will be build for each user each time they access it:
https://mybinder.org/v2/gh/alansaul/binder_test/main
